### PR TITLE
feat: use Trusted Publishing in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -184,8 +184,9 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' }}
     needs: [linux, musllinux, windows, macos, sdist]
+    environment: pypi
     permissions:
-      # Use to sign the release artifacts
+      # Use to sign the release artifacts and for Trusted Publishing
       id-token: write
       # Used to upload release artifacts
       contents: write
@@ -200,8 +201,6 @@ jobs:
       - name: Publish to PyPI
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
         uses: PyO3/maturin-action@v1
-        env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         with:
           command: upload
           args: --non-interactive --skip-existing wheels-*/*


### PR DESCRIPTION
Can now delete the PyPI token from CI...

On review there never was one, so CI was not being used to publish this package?
