### PR TITLE
feat: new text handlers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,7 @@ name = "htmd-py"
 version = "0.1.1"
 dependencies = [
  "htmd",
+ "markup5ever_rcdom",
  "pyo3",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [dependencies]
 htmd_lib = {package = "htmd", version = "0.5.4"}
+markup5ever_rcdom = "0.38.0"
 pyo3 = "0.28"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -110,6 +110,28 @@ htmd.TranslationMode.FAITHFUL   # "faithful"
 
 `ul_bullet_spacing` and `ol_number_spacing` are plain integers rather than enum-like constants — any value in the `u8` range (0–255) is valid.
 
+### Text-only handler options
+
+Three additional options on `Options` for plain-text-style markdown
+(useful for data ingestion pipelines):
+
+- `image_placeholder`: Optional template string for `<img>` elements.
+  `{alt}` is substituted for the alt attribute (`Optional[str]`)
+- `drop_empty_alt_images`: Drop `<img>` with empty or missing alt (boolean)
+- `drop_image_only_links`: Unwrap `<a>` whose only element child is an
+  `<img>` (boolean)
+
+```python
+import htmd
+
+opts = htmd.Options()
+opts.image_placeholder = "[Image: {alt}]"
+opts.drop_empty_alt_images = True
+opts.drop_image_only_links = True
+markdown = htmd.convert_html('<a href="..."><img alt="logo"></a>', opts)
+print(markdown)  # "[Image: logo]"
+```
+
 ## Benchmarks
 
 Tested with small (12 lines) and medium (1000 lines) markdown strings

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,5 +1,8 @@
+use std::rc::Rc;
+
 use pyo3::prelude::*;
 
+use htmd_lib::element_handler::{HandlerResult, Handlers};
 use htmd_lib::options::{
     BrStyle as HtmdBrStyle, BulletListMarker as HtmdBulletListMarker,
     CodeBlockFence as HtmdCodeBlockFence, CodeBlockStyle as HtmdCodeBlockStyle,
@@ -7,7 +10,36 @@ use htmd_lib::options::{
     LinkReferenceStyle as HtmdLinkReferenceStyle, LinkStyle as HtmdLinkStyle,
     Options as HtmdOptions, TranslationMode as HtmdTranslationMode,
 };
-use htmd_lib::HtmlToMarkdownBuilder;
+use htmd_lib::{Element, HtmlToMarkdownBuilder};
+use markup5ever_rcdom::{Node, NodeData};
+
+/// True if `node`'s direct children are exactly one `<img>` element, with
+/// any other children being whitespace-only text nodes. Comments, doctype,
+/// and processing instructions are ignored.
+fn is_image_only_anchor(node: &Rc<Node>) -> bool {
+    let children = node.children.borrow();
+    let mut saw_image = false;
+    for child in children.iter() {
+        match &child.data {
+            NodeData::Text { contents } => {
+                if !contents.borrow().chars().all(char::is_whitespace) {
+                    return false;
+                }
+            }
+            NodeData::Element { name, .. } => {
+                if &*name.local != "img" {
+                    return false;
+                }
+                if saw_image {
+                    return false;
+                }
+                saw_image = true;
+            }
+            _ => {}
+        }
+    }
+    saw_image
+}
 
 /// Python class that mirrors htmd's `Options`
 #[pyclass(name = "Options", from_py_object)]
@@ -41,6 +73,25 @@ pub struct PyOptions {
     // Special attributes that don't map directly to HtmdOptions
     #[pyo3(get, set)]
     pub skip_tags: Vec<String>,
+
+    /// Custom image replacement template. When set, `<img>` elements are
+    /// replaced with this string, with `{alt}` substituted for the alt
+    /// attribute's value. When `None`, htmd's default `![alt](src)`
+    /// rendering is used.
+    #[pyo3(get, set)]
+    pub image_placeholder: Option<String>,
+
+    /// When true, `<img>` elements whose alt attribute is empty or missing
+    /// are dropped from the output. Composes with `image_placeholder`:
+    /// non-empty alts use the template, empty alts are dropped.
+    #[pyo3(get, set)]
+    pub drop_empty_alt_images: bool,
+
+    /// When true, `<a>` elements whose only element child is an `<img>`
+    /// (with optional whitespace-only text siblings) are unwrapped: the
+    /// inner image render is emitted without the surrounding link.
+    #[pyo3(get, set)]
+    pub drop_image_only_links: bool,
 }
 
 impl PyOptions {
@@ -120,6 +171,51 @@ impl PyOptions {
             builder = builder.skip_tags(skip_tags);
         }
 
+        // Install custom <img> handler if image_placeholder or drop_empty_alt_images is set.
+        let wants_img_handler =
+            self.image_placeholder.is_some() || self.drop_empty_alt_images;
+        if wants_img_handler {
+            let template = self.image_placeholder.clone();
+            let drop_empty = self.drop_empty_alt_images;
+            builder = builder.add_handler(
+                vec!["img"],
+                move |handlers: &dyn Handlers, element: Element| -> Option<HandlerResult> {
+                    let alt = element
+                        .attrs
+                        .iter()
+                        .find(|a| &*a.name.local == "alt")
+                        .map(|a| a.value.to_string())
+                        .unwrap_or_default();
+                    let alt_trimmed = alt.trim();
+
+                    if alt_trimmed.is_empty() && drop_empty {
+                        return Some(HandlerResult::from(String::new()));
+                    }
+
+                    if let Some(ref t) = template {
+                        let replaced = t.replace("{alt}", alt_trimmed);
+                        return Some(HandlerResult::from(replaced));
+                    }
+
+                    handlers.fallback(element)
+                },
+            );
+        }
+
+        // Install custom <a> handler that unwraps image-only links.
+        if self.drop_image_only_links {
+            builder = builder.add_handler(
+                vec!["a"],
+                move |handlers: &dyn Handlers, element: Element| -> Option<HandlerResult> {
+                    if is_image_only_anchor(element.node) {
+                        let inner = handlers.walk_children(element.node);
+                        return Some(HandlerResult::from(inner.content));
+                    }
+                    handlers.fallback(element)
+                },
+            );
+        }
+
         builder
     }
 }
@@ -186,6 +282,11 @@ impl PyOptions {
 
             // Special attributes
             skip_tags: Vec::new(),
+
+            // Text-only handler options
+            image_placeholder: None,
+            drop_empty_alt_images: false,
+            drop_image_only_links: false,
         }
     }
 }

--- a/tests/options_test.py
+++ b/tests/options_test.py
@@ -17,6 +17,9 @@ EXPECTED_DEFAULTS = {
     "ol_number_spacing": 2,
     "preformatted_code": False,
     "translation_mode": "pure",
+    "image_placeholder": None,
+    "drop_empty_alt_images": False,
+    "drop_image_only_links": False,
 }
 
 
@@ -50,6 +53,10 @@ def test_default_skip_tags_empty(opts):
         ("ol_number_spacing", 3),
         ("preformatted_code", True),
         ("skip_tags", ["script", "style"]),
+        ("image_placeholder", "[Image: {alt}]"),
+        ("image_placeholder", None),
+        ("drop_empty_alt_images", True),
+        ("drop_image_only_links", True),
     ],
 )
 def test_attribute_roundtrip(opts, attr, value):

--- a/tests/text_only_handlers_test.py
+++ b/tests/text_only_handlers_test.py
@@ -1,0 +1,307 @@
+"""Tests for the text-only handler options: image_placeholder,
+drop_empty_alt_images, drop_image_only_links.
+
+These three knobs install custom Rust-side handlers via add_handler when
+their corresponding fields are set. Tests cover each knob in isolation,
+their interactions, and the structural-detection edge cases that motivated
+DOM-based detection over rendered-output prefix matching.
+"""
+
+import htmd
+
+
+# --- image_placeholder ------------------------------------------------------
+
+
+class TestImagePlaceholder:
+    """Custom <img> rendering via template with {alt} substitution."""
+
+    def test_default_renders_markdown_image(self):
+        """No placeholder set → htmd's default ![alt](src) rendering."""
+        out = htmd.convert_html('<img src="x.png" alt="foo">')
+        assert "![foo](x.png)" in out
+
+    def test_template_substitutes_alt(self):
+        opts = htmd.Options()
+        opts.image_placeholder = "[Image: {alt}]"
+        out = htmd.convert_html('<img src="x.png" alt="foo">', opts)
+        assert "[Image: foo]" in out
+        assert "x.png" not in out  # src is dropped
+
+    def test_template_with_empty_alt(self):
+        """Empty alt becomes empty string in template, not the literal '{alt}'."""
+        opts = htmd.Options()
+        opts.image_placeholder = "[Image: {alt}]"
+        out = htmd.convert_html('<img src="x.png" alt="">', opts)
+        assert "[Image: ]" in out
+
+    def test_template_with_missing_alt_attribute(self):
+        """No alt attribute is treated the same as empty alt."""
+        opts = htmd.Options()
+        opts.image_placeholder = "[Image: {alt}]"
+        out = htmd.convert_html('<img src="x.png">', opts)
+        assert "[Image: ]" in out
+
+    def test_template_trims_alt_whitespace(self):
+        """Alt text is trimmed before substitution."""
+        opts = htmd.Options()
+        opts.image_placeholder = "[Image: {alt}]"
+        out = htmd.convert_html('<img src="x.png" alt="  foo  ">', opts)
+        assert "[Image: foo]" in out
+
+    def test_template_without_alt_token(self):
+        """Template without {alt} still works — it's just a literal string."""
+        opts = htmd.Options()
+        opts.image_placeholder = "[IMAGE]"
+        out = htmd.convert_html('<img src="x.png" alt="anything">', opts)
+        assert "[IMAGE]" in out
+
+    def test_template_with_special_markdown_chars_in_alt(self):
+        """Brackets in alt text are inserted verbatim; HandlerResult bypasses
+        the text-node escaping that would normally backslash-escape them."""
+        opts = htmd.Options()
+        opts.image_placeholder = "[Image: {alt}]"
+        out = htmd.convert_html('<img src="x.png" alt="![foo]">', opts)
+        assert "[Image: ![foo]]" in out
+
+
+# --- drop_empty_alt_images --------------------------------------------------
+
+
+class TestDropEmptyAltImages:
+    """Drop <img> elements whose alt is empty or missing."""
+
+    def test_default_keeps_empty_alt(self):
+        out = htmd.convert_html('<p>before<img src="x.png" alt="">after</p>')
+        # Default htmd rendering keeps the image; exact form is `![](x.png)`.
+        assert "![" in out
+
+    def test_drops_empty_alt(self):
+        opts = htmd.Options()
+        opts.drop_empty_alt_images = True
+        out = htmd.convert_html(
+            '<p>before<img src="x.png" alt="">after</p>',
+            opts,
+        )
+        assert "x.png" not in out
+        assert "![" not in out
+        assert "before" in out
+        assert "after" in out
+
+    def test_drops_missing_alt_attribute(self):
+        opts = htmd.Options()
+        opts.drop_empty_alt_images = True
+        out = htmd.convert_html('<p>before<img src="x.png">after</p>', opts)
+        assert "x.png" not in out
+        assert "before" in out
+        assert "after" in out
+
+    def test_drops_whitespace_only_alt(self):
+        opts = htmd.Options()
+        opts.drop_empty_alt_images = True
+        out = htmd.convert_html(
+            '<p>x<img src="x.png" alt="   ">y</p>',
+            opts,
+        )
+        assert "x.png" not in out
+
+    def test_keeps_nonempty_alt_with_default_rendering(self):
+        """Without a custom template, non-empty alts get htmd's default
+        ![alt](src) rendering (handler defers to fallback)."""
+        opts = htmd.Options()
+        opts.drop_empty_alt_images = True
+        out = htmd.convert_html('<img src="x.png" alt="kept">', opts)
+        assert "![kept](x.png)" in out
+
+
+# --- image_placeholder + drop_empty_alt_images ------------------------------
+
+
+class TestImagePlaceholderWithDropEmpty:
+    """Both knobs set: non-empty alts use the template, empty alts dropped."""
+
+    def test_non_empty_alt_uses_template(self):
+        opts = htmd.Options()
+        opts.image_placeholder = "[Image: {alt}]"
+        opts.drop_empty_alt_images = True
+        out = htmd.convert_html('<img src="x.png" alt="foo">', opts)
+        assert "[Image: foo]" in out
+
+    def test_empty_alt_dropped_not_templated(self):
+        opts = htmd.Options()
+        opts.image_placeholder = "[Image: {alt}]"
+        opts.drop_empty_alt_images = True
+        out = htmd.convert_html(
+            '<p>x<img src="x.png" alt="">y</p>',
+            opts,
+        )
+        assert "[Image:" not in out
+        assert "x.png" not in out
+        assert "x" in out and "y" in out
+
+
+# --- drop_image_only_links: structural detection cases ---------------------
+
+
+class TestDropImageOnlyLinks:
+    """Structural detection: anchor's direct children must be exactly one
+    <img> element plus only whitespace text siblings."""
+
+    def test_default_keeps_link_around_image(self):
+        out = htmd.convert_html(
+            '<a href="https://example.com"><img src="x.png" alt="foo"></a>',
+        )
+        # Default: link wraps image, both rendered.
+        assert "https://example.com" in out
+        assert "![foo](x.png)" in out
+
+    def test_unwraps_bare_image_only_link(self):
+        opts = htmd.Options()
+        opts.drop_image_only_links = True
+        out = htmd.convert_html(
+            '<a href="https://example.com"><img src="x.png" alt="foo"></a>',
+            opts,
+        )
+        assert "https://example.com" not in out
+        assert "![foo](x.png)" in out
+
+    def test_unwraps_with_whitespace_siblings(self):
+        """Pretty-printed HTML with whitespace text nodes around the image
+        still counts as image-only — that's the natural form from any HTML
+        formatter."""
+        opts = htmd.Options()
+        opts.drop_image_only_links = True
+        html = '<a href="https://example.com">\n  <img src="x.png" alt="foo">\n</a>'
+        out = htmd.convert_html(html, opts)
+        assert "https://example.com" not in out
+        assert "![foo](x.png)" in out
+
+    def test_keeps_link_with_image_plus_text(self):
+        """The motivating false-positive: <a><img> text</a> must NOT be
+        unwrapped — the rendered markdown starts with the image marker but
+        the link semantically wraps both image and text."""
+        opts = htmd.Options()
+        opts.drop_image_only_links = True
+        out = htmd.convert_html(
+            '<a href="https://example.com"><img src="x.png" alt="foo"> Read more</a>',
+            opts,
+        )
+        # Link must survive: structural check sees a non-whitespace text sibling.
+        assert "https://example.com" in out
+        assert "Read more" in out
+
+    def test_keeps_link_with_two_images(self):
+        opts = htmd.Options()
+        opts.drop_image_only_links = True
+        out = htmd.convert_html(
+            '<a href="https://example.com">'
+            '<img src="a.png" alt="a"><img src="b.png" alt="b">'
+            "</a>",
+            opts,
+        )
+        assert "https://example.com" in out
+
+    def test_keeps_link_with_image_plus_other_element(self):
+        opts = htmd.Options()
+        opts.drop_image_only_links = True
+        out = htmd.convert_html(
+            '<a href="https://example.com">'
+            '<img src="x.png" alt="foo"><span>caption</span>'
+            "</a>",
+            opts,
+        )
+        assert "https://example.com" in out
+        assert "caption" in out
+
+    def test_keeps_link_with_only_text(self):
+        """Plain text-only links are unaffected — fallback handles them."""
+        opts = htmd.Options()
+        opts.drop_image_only_links = True
+        out = htmd.convert_html(
+            '<a href="https://example.com">click me</a>',
+            opts,
+        )
+        assert "[click me](https://example.com)" in out
+
+    def test_keeps_link_with_no_children(self):
+        """<a></a> has no img child, so structural check fails — fallback."""
+        opts = htmd.Options()
+        opts.drop_image_only_links = True
+        out = htmd.convert_html(
+            '<a href="https://example.com"></a>',
+            opts,
+        )
+        # Empty link goes through fallback. We don't assert exact rendering,
+        # just that no crash and the option didn't unwrap into nothing.
+        assert isinstance(out, str)
+
+
+# --- drop_image_only_links + other knobs ------------------------------------
+
+
+class TestDropImageOnlyLinksWithOtherKnobs:
+    """The unwrapped inner walk uses whatever <img> handler chain is active."""
+
+    def test_unwrapped_image_uses_custom_template(self):
+        opts = htmd.Options()
+        opts.image_placeholder = "[Image: {alt}]"
+        opts.drop_image_only_links = True
+        out = htmd.convert_html(
+            '<a href="https://example.com"><img src="x.png" alt="foo"></a>',
+            opts,
+        )
+        assert "https://example.com" not in out
+        assert "[Image: foo]" in out
+
+    def test_unwrapped_empty_alt_image_with_drop_empty_emits_nothing(self):
+        """When drop_image_only_links + drop_empty_alt_images both apply to
+        an empty-alt image inside an anchor, the structural check still
+        passes (the <img> element exists), the inner walk emits empty string
+        (image dropped), and the anchor unwraps to empty.
+
+        Net effect: the entire <a><img></a> disappears, which is the
+        intended LLM-ingestion behavior — no link, no image, no chrome."""
+        opts = htmd.Options()
+        opts.drop_empty_alt_images = True
+        opts.drop_image_only_links = True
+        out = htmd.convert_html(
+            '<p>before<a href="https://example.com">'
+            '<img src="x.png" alt=""></a>after</p>',
+            opts,
+        )
+        assert "https://example.com" not in out
+        assert "x.png" not in out
+        assert "before" in out
+        assert "after" in out
+
+    def test_link_with_only_dropped_image_still_classified_as_image_only(self):
+        """Variant of the above with whitespace siblings — same outcome."""
+        opts = htmd.Options()
+        opts.drop_empty_alt_images = True
+        opts.drop_image_only_links = True
+        html = (
+            '<p>x<a href="https://example.com">\n  <img src="x.png" alt="">\n</a>y</p>'
+        )
+        out = htmd.convert_html(html, opts)
+        assert "https://example.com" not in out
+        assert "x" in out and "y" in out
+
+
+# --- Regression test for the prefix-matching false positive ----------------
+
+
+def test_link_with_image_then_text_does_not_unwrap_with_custom_template():
+    """The original heuristic (string-prefix matching) would unwrap this case
+    when image_placeholder = "[Image: {alt}]" because the rendered inner
+    content "[Image: foo] Read more" starts with "[Image: ". Structural
+    detection prevents this — the anchor has a non-whitespace text sibling,
+    so it's not image-only and the link survives."""
+    opts = htmd.Options()
+    opts.image_placeholder = "[Image: {alt}]"
+    opts.drop_image_only_links = True
+    out = htmd.convert_html(
+        '<a href="https://example.com"><img src="x.png" alt="foo"> Read more</a>',
+        opts,
+    )
+    assert "https://example.com" in out
+    assert "Read more" in out


### PR DESCRIPTION
Adds three options to `Options` for plain-text-style markdown (discussed in #37), all off by default:

- `image_placeholder: Optional[str]` — template for `<img>`, with `{alt}` substituted.
  - Default `None` keeps htmd's `![alt](src)`.
- `drop_empty_alt_images: bool` — drop `<img>` with empty/missing alt. Composes with `image_placeholder`.
- `drop_image_only_links: bool` — unwrap `<a>` whose only element child is an `<img>`.

## Implementation

Handlers are installed Rust-side via `add_handler`.

For `drop_image_only_links`, an anchor counts as image-only when its direct children are exactly one `<img>` plus any whitespace text nodes. This is checked structurally on the DOM rather than by inspecting the rendered markdown, so `<a><img alt="foo"> Read more</a>` is correctly preserved (the trailing text disqualifies it), and the check works the same regardless of what the `<img>` handler renders.

Adds `markup5ever_rcdom = "0.38"` as a direct dep (matches htmd's pin).

## Tests

- `tests/text_only_handlers_test.py` covers each option, combinations, and structural edge cases.
- `tests/options_test.py` extended for the new fields' defaults and round-tripping.


